### PR TITLE
Deps: remove version contraints from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,13 +6,13 @@ ruby '2.6.3'
 gem 'rails', '~> 5.2.3'
 
 gem 'pg'
-gem 'puma', '~> 3.11'
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
+gem 'puma'
+gem 'sass-rails'
+gem 'uglifier'
 
-gem 'turbolinks', '~> 5'
-gem 'bcrypt', '~> 3.1.7'
-gem 'bootsnap', '>= 1.1.0', require: false
+gem 'turbolinks'
+gem 'bcrypt'
+gem 'bootsnap', require: false
 
 group :development, :test do
   gem 'byebug'
@@ -20,14 +20,14 @@ group :development, :test do
 end
 
 group :development do
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console'
+  gem 'listen'
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen'
 end
 
 group :test do
-  gem 'capybara', '>= 2.15'
+  gem 'capybara'
   gem 'selenium-webdriver'
   gem 'chromedriver-helper'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,23 +202,23 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcrypt (~> 3.1.7)
-  bootsnap (>= 1.1.0)
+  bcrypt
+  bootsnap
   byebug
-  capybara (>= 2.15)
+  capybara
   chromedriver-helper
-  listen (>= 3.0.5, < 3.2)
+  listen
   pg
-  puma (~> 3.11)
+  puma
   rails (~> 5.2.3)
   rspec-rails
-  sass-rails (~> 5.0)
+  sass-rails
   selenium-webdriver
   spring
-  spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
-  uglifier (>= 1.3.0)
-  web-console (>= 3.3.0)
+  spring-watcher-listen
+  turbolinks
+  uglifier
+  web-console
 
 RUBY VERSION
    ruby 2.6.3p62


### PR DESCRIPTION
That's what `Gemfile.lock` is for. We leave the `rails` one locked,
though, since it's the entire backbone of our application. It's nice to
have informationally and we probably want to give it extra consideration
when upgrading.